### PR TITLE
fix(main): Fix typo in variable name in context.ts

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -66,7 +66,7 @@ export class Context {
     const ast = parse(code);
     const ms = new MagicString(code);
     let sourceWithoutRoot = "";
-    let props: string[] = ['ref="unLayout"'];
+    let props: string[] = ['ref="uniLayout"'];
     let dynamicLayout = "";
     const rootTemplate = ast.children.find(
       (node) => node.type === 1 && node.tag === "template"


### PR DESCRIPTION
“context.ts”文件中引用道具名称的拼写错误导致引用问题。”unLayout”已更正为“uniLayout”，以保持整个代码库的一致性，并消除可能由错误引用引起的潜在错误

### Description 描述

ref
只需声明一个 ref 变量 uniLayout 即可访问

<script setup>
const uniLayout = ref()
</script>

uniLayout 变量名称错误 unLayout