### PR TITLE
fix Win环境isSrcMode判断错误导致layout失效的bug

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,7 +50,7 @@ export function getTarget(
   if (!(resolvePath.endsWith('.vue') || resolvePath.endsWith('.nvue')))
     return false
   let isSrcMode = false
-  if (resolvePath.startsWith(join(cwd, 'src')))
+  if (resolvePath.startsWith(normalizePath(join(cwd, 'src'))))
     isSrcMode = true
   const relativePath = relative(join(cwd, isSrcMode ? 'src' : ''), resolvePath)
   const fileWithoutExt = path.basename(


### PR DESCRIPTION
Win环境isSrcMode判断错误导致layout失效，解决办法是使用normalizePath包裹一下join(cwd, 'src')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path resolution to ensure more accurate targeting within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->