### PR TITLE
HMR

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -47,6 +47,8 @@ export class Context {
           return pre && pre.layout !== newPage.layout
         })
 
+        const viteRoot = this._server!.config.root
+
         // 失效对应的模块，触发 transform
         if (this._server && changedPages.length > 0) {
           for (const page of changedPages) {
@@ -54,7 +56,7 @@ export class Context {
             const pagePathVue = normalizePath(
               resolve('/src', `${page.path}.vue`),
             )
-            fs.access(resolve('src', `${page.path}.vue`), fs.constants.F_OK, (err) => {
+            fs.access(resolve(viteRoot, 'src', `${page.path}.vue`), fs.constants.F_OK, (err) => {
               if (!err)
                 invalidateAndReload(pagePathVue, this._server)
             })
@@ -63,7 +65,7 @@ export class Context {
             const pagePathNv = normalizePath(
               resolve('/src', `${page.path}.nvue`),
             )
-            fs.access(resolve('src', `${page.path}.nvue`), fs.constants.F_OK, (err) => {
+            fs.access(resolve(viteRoot, 'src', `${page.path}.nvue`), fs.constants.F_OK, (err) => {
               if (!err)
                 invalidateAndReload(pagePathNv, this._server)
             })

--- a/src/context.ts
+++ b/src/context.ts
@@ -40,10 +40,11 @@ export class Context {
         const prePages = this.pages
         this.pages = loadPagesJson(this.pageJsonPath, this.options.cwd)
 
-        // 找出layout发生变化的页面
-        const changedPages = this.pages.filter((newPage, index) => {
-          const prePage = prePages[index]
-          return prePage && prePage.layout !== newPage.layout
+        // 找出 layout 发生变化的页面（按 path 对齐）
+        const preByPath = new Map(prePages.map(p => [normalizePath(p.path), p]))
+        const changedPages = this.pages.filter((newPage) => {
+          const pre = preByPath.get(normalizePath(newPage.path))
+          return pre && pre.layout !== newPage.layout
         })
 
         // 失效对应的模块，触发 transform

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -1,12 +1,10 @@
-import { basename, dirname, extname, join, relative, resolve } from 'node:path'
-import process from 'node:process'
+import { basename, dirname, extname, join, relative } from 'node:path'
 import fg from 'fast-glob'
 import { camelCase, kebabCase, pascalCase, splitByCase } from 'scule'
 import { normalizePath } from 'vite'
 import type { Layout } from './types'
 
-export function scanLayouts(dir = 'src/layouts', cwd = process.cwd()) {
-  dir = resolve(cwd, dir)
+export function scanLayouts(dir: string) {
   const files = fg.sync('**/*.vue', {
     onlyFiles: true,
     ignore: ['node_modules', '.git', '**/__*__/*'],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,3 +120,10 @@ export async function invalidateAndReload(filePath: string, server?: ViteDevServ
     return false
   }
 }
+
+/** 检查路径是否在 layouts 目录下 */
+export function isLayoutFile(filePath: string, layoutDirPath: string) {
+  const normalizedPath = normalizePath(filePath)
+  const normalizedLayoutDir = normalizePath(layoutDirPath)
+  return normalizedPath.startsWith(normalizedLayoutDir) && (normalizedPath.endsWith('.vue') || normalizedPath.endsWith('.nvue'))
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import type { SFCDescriptor } from '@vue/compiler-sfc'
 import { parse as VueParser } from '@vue/compiler-sfc'
 import { parse as jsonParse } from 'jsonc-parser'
 import { normalizePath } from 'vite'
+import type { ViteDevServer } from 'vite'
 import type { Page, ResolvedOptions, UserOptions } from './types'
 
 function slash(str: string) {
@@ -90,5 +91,32 @@ export async function parseSFC(code: string): Promise<SFCDescriptor> {
     throw new Error(
       '[vite-plugin-uni-layouts] Vue3\'s "@vue/compiler-sfc" is required.',
     )
+  }
+}
+
+// 使模块失效并重新加载
+export async function invalidateAndReload(filePath: string, server?: ViteDevServer) {
+  if (!server) {
+    console.error('Vite server not available.')
+    return false
+  }
+
+  const module = await server.moduleGraph.getModuleByUrl(filePath)
+
+  if (module) {
+    // 1. 使模块失效
+    // 这会清除模块的 transform 缓存，并标记它需要重新加载
+    // 同时也会遍历所有导入它的模块并传递失效状态
+    server.moduleGraph.invalidateModule(module)
+
+    // 2. 通知 HMR
+    // 告诉浏览器该模块（及其所有依赖它的模块）需要重新加载
+    server.reloadModule(module)
+
+    return true
+  }
+  else {
+    console.warn(`[vite-plugin-uni-layouts] ❌ Module not found in module graph: ${filePath}`)
+    return false
   }
 }


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

**1. 监听 pages.json 中页面 layout 变化，针对变改的页面，重新触发 transform。**

看之前的机制，更新 `pages.json` 后，`vite` 会触发所有文件的 `transfrom`。 其实没更新 `layout` 的页面并不需要，造成了浪费。
而且更新 `vite` 版本到 5.2.8（目前 uni app 官方模板）后，更新 `pages.json` 并不会触发所有文件的 `transfrom`。这样导致开发过程中，你动态更新 `pages.json` 并不生效，要重新运行 `dev` 命令才能生效

**2. fix: 开发过程中，在layouts 目录下新增了 layout 文件，页面使用该 layout 无法生效**

新增 layout 文件，无法生效，要重新运行 `dev` 命令才能生效。而且如果删除某个 layout, `vite` 还会报错无法找到当前文件

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

### Linked Issues 关联的 Issues

### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic page reloads when layout configurations change during development to reduce manual refreshes.
  * Targeted reloads for only affected page files (including Vue/NVue) to minimize unnecessary restarts and speed up feedback.
  * Smarter watcher behavior that ignores irrelevant events and skips reloads when no layout changes are detected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->